### PR TITLE
use upper as cutoff speed in integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMaxwellVlasov"
 uuid = "b1137d70-0135-468f-bb3e-ace6f597c457"
 authors = ["James Cook <cookjws@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/tensors/CoupledVelocity.jl
+++ b/src/tensors/CoupledVelocity.jl
@@ -50,7 +50,7 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies,
     end
 
     output = @SArray [M11 M12 M13; M21 M22 M23; M31 M32 M33]
-    @assert !any(isnan, output) "output = $output, vz⊥=$vz⊥"
+    @assert !any(isnan, output) "output = $output, vz⊥=$vz⊥, $dfdvz, $dfdv⊥"
 
     return output
   end
@@ -58,8 +58,9 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies,
   integrand(vz⊥) = numerator(vz⊥) * invdenominator(vz⊥[1])
 
   function integral2D()
-    return first(HCubature.hcubature(integrand,
-      (-S.F.upper, S.F.lower), (S.F.upper, S.F.upper), initdiv=64,
+    ∫dvrdθ(vrθ) = vrθ[1] * integrand(parallelperpfrompolar(vrθ))
+    return first(HCubature.hcubature(∫dvrdθ,
+      (S.F.lower, -π / 2), (S.F.upper, π / 2), initdiv=64,
       rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs))
   end
 

--- a/test/tensors/CoupledVsSeparable.jl
+++ b/test/tensors/CoupledVsSeparable.jl
@@ -5,7 +5,6 @@ using Test, Random
 using LinearMaxwellVlasov
 const LMV = LinearMaxwellVlasov
 
-
 Random.seed!(0)
 
 @testset "Separable vs Coupled velocity tensors" begin
@@ -33,15 +32,13 @@ Random.seed!(0)
     for (coupled, separable) ∈ ((coupledMaxwellian, separableMaxwellian),
                                 (coupledRingBeam, separableRingBeam), )
       k = Ω / Va / 2
-      ω0 = abs(vth * k) / 2
+      ωr = real(abs(vth * abs(k))) # real ωr must be > 0
       rtol=1e-4
       atol=eps()
-      ωrs = (ω0, 2ω0, ω0 + Ω)
       σs = (-1, 0, 1)
       kzs = (-k, 0k, k)
-      for params ∈ zip(ωrs, σs, kzs)
-        (ωr, σ, kz) = params
-        ωr = abs(real(ωr)) # real ωr must be > 0
+      for params ∈ zip(σs, kzs)
+        (σ, kz) = params
         F = ComplexF64(ωr, σ * ωr / 100)
         K = Wavenumber(kz=kz, k⊥=k)
         config = Configuration(F, K)

--- a/test/tensors/NumericalVsMaxwellian.jl
+++ b/test/tensors/NumericalVsMaxwellian.jl
@@ -5,8 +5,6 @@ using Test
 using LinearMaxwellVlasov
 const LMV = LinearMaxwellVlasov
 
-
-
 @testset "Maxwellian vs Numerical tensors" begin
   mₑ = LMV.mₑ
   mi = 1836*mₑ
@@ -59,14 +57,14 @@ const LMV = LinearMaxwellVlasov
         @inferred LMV.contribution(species, C, 0)
         @test true
       catch
-          @warn "contribution not inferred for $(nameof(typeof(species)))"
+        @warn "contribution not inferred for $(nameof(typeof(species)))"
         @test_broken false
       end
       try
         @inferred LMV.contribution(species, C)
         @test true
       catch
-          @warn "contribution not inferred for $(nameof(typeof(species)))"
+        @warn "contribution not inferred for $(nameof(typeof(species)))"
         @test_broken false
       end
     end


### PR DESCRIPTION
Use the upper speed limit of the coupled species as a hard cutoff for the integration in order to facilitate Heaviside functions that cut off distribution functions after a specific speed.