### PR TITLE
Cubaturemaxevals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMaxwellVlasov"
 uuid = "b1137d70-0135-468f-bb3e-ace6f597c457"
 authors = ["James Cook <cookjws@gmail.com>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -4,14 +4,17 @@ struct Options{T<:Number}
   summation_tol::Tolerance{T}
   memoiseparallel::Bool
   memoiseperpendicular::Bool
+  cubature_maxevals::Int
   _uniqueid::UInt64
   function Options(quadrature_tol::Tolerance{T},
       summation_tol::Tolerance{T},
-      memoiseparallel::Bool, memoiseperpendicular::Bool) where {T<:Number}
+      memoiseparallel::Bool, memoiseperpendicular::Bool,
+      cubature_maxevals::Int) where {T<:Number}
     _uniqueid = hash((quadrature_tol, summation_tol,
-      memoiseparallel, memoiseperpendicular), hash(:Options))
+      memoiseparallel, memoiseperpendicular, cubature_maxevals), hash(:Options))
     return new{T}(quadrature_tol, summation_tol,
-      memoiseparallel, memoiseperpendicular, _uniqueid)
+      memoiseparallel, memoiseperpendicular,
+      cubature_maxevals, _uniqueid)
   end
 end
 uniqueid(o::Options) = o._uniqueid
@@ -35,6 +38,7 @@ function defaults(::Type{T}=Float64) where {T}
   output[:summation_atol] = zero(T)
   output[:memoiseparallel] = true
   output[:memoiseperpendicular] = true
+  output[:cubature_maxevals] = typemax(Int)
   return output
 end
 
@@ -62,7 +66,10 @@ function Options(::Type{T}=Float64; kwargstuple...) where {T}
     :quad_atol => :quadrature_atol, :quad_rtol => :quadrature_rtol,
     :sum_atol => :summation_atol, :sum_rtol => :summation_rtol,
     :atols => (:quadrature_atol, :summation_atol),
-    :rtols => (:quadrature_rtol, :summation_rtol),)
+    :rtols => (:quadrature_rtol, :summation_rtol),
+    :maxevals => :cubature_maxevals,
+    :cuba_evals => :cubature_maxevals,
+   )
 
   for (kwargkey, argkeys) ∈ specialcasekeys
     haskey(kwargs, kwargkey) || continue
@@ -79,5 +86,6 @@ function Options(::Type{T}=Float64; kwargstuple...) where {T}
   quadrature_tol = Tolerance{T}(args[:quadrature_rtol], args[:quadrature_atol])
   summation_tol = Tolerance{T}(args[:summation_rtol], args[:summation_atol])
   return Options(quadrature_tol, summation_tol,
-    args[:memoiseparallel], args[:memoiseperpendicular])
+    args[:memoiseparallel], args[:memoiseperpendicular],
+    args[:cubature_maxevals])
 end

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -1,18 +1,20 @@
 
 struct Options{T<:Number}
   quadrature_tol::Tolerance{T}
+  cubature_tol::Tolerance{T}
   summation_tol::Tolerance{T}
   memoiseparallel::Bool
   memoiseperpendicular::Bool
   cubature_maxevals::Int
   _uniqueid::UInt64
   function Options(quadrature_tol::Tolerance{T},
+      cubature_tol::Tolerance{T},
       summation_tol::Tolerance{T},
       memoiseparallel::Bool, memoiseperpendicular::Bool,
       cubature_maxevals::Int) where {T<:Number}
-    _uniqueid = hash((quadrature_tol, summation_tol,
+    _uniqueid = hash((quadrature_tol, cubature_tol, summation_tol,
       memoiseparallel, memoiseperpendicular, cubature_maxevals), hash(:Options))
-    return new{T}(quadrature_tol, summation_tol,
+    return new{T}(quadrature_tol, cubature_tol, summation_tol,
       memoiseparallel, memoiseperpendicular,
       cubature_maxevals, _uniqueid)
   end
@@ -33,8 +35,10 @@ The default settings for the Options object.
 function defaults(::Type{T}=Float64) where {T}
   output = Dict{Symbol, Any}()
   output[:quadrature_rtol] = eps(T)^(3//4)
+  output[:cubature_rtol] = eps(T)^(3//4)
   output[:summation_rtol] = eps(T)^(3//4)
   output[:quadrature_atol] = zero(T)
+  output[:cubature_atol] = zero(T)
   output[:summation_atol] = zero(T)
   output[:memoiseparallel] = true
   output[:memoiseperpendicular] = true
@@ -64,9 +68,10 @@ function Options(::Type{T}=Float64; kwargstuple...) where {T}
   end
   specialcasekeys = Dict{Symbol, Any}(
     :quad_atol => :quadrature_atol, :quad_rtol => :quadrature_rtol,
+    :cuba_atol => :cubature_atol, :cuba_rtol => :cubature_rtol,
     :sum_atol => :summation_atol, :sum_rtol => :summation_rtol,
-    :atols => (:quadrature_atol, :summation_atol),
-    :rtols => (:quadrature_rtol, :summation_rtol),
+    :atols => (:quadrature_atol, :summation_atol, :cubature_atol),
+    :rtols => (:quadrature_rtol, :summation_rtol, :cubature_rtol),
     :maxevals => :cubature_maxevals,
     :cuba_evals => :cubature_maxevals,
    )
@@ -84,8 +89,9 @@ function Options(::Type{T}=Float64; kwargstuple...) where {T}
     args[key] = kwargs[key]
   end
   quadrature_tol = Tolerance{T}(args[:quadrature_rtol], args[:quadrature_atol])
+  cubature_tol = Tolerance{T}(args[:cubature_rtol], args[:cubature_atol])
   summation_tol = Tolerance{T}(args[:summation_rtol], args[:summation_atol])
-  return Options(quadrature_tol, summation_tol,
+  return Options(quadrature_tol, cubature_tol, summation_tol,
     args[:memoiseparallel], args[:memoiseperpendicular],
     args[:cubature_maxevals])
 end

--- a/src/tensors/CoupledVelocity.jl
+++ b/src/tensors/CoupledVelocity.jl
@@ -241,7 +241,8 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies, C::Configuration)
   function integral2D()
     return first(HCubature.hcubature(integrand,
       (-S.F.upper, lower), (S.F.upper, S.F.upper), initdiv=16,
-      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs))
+      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs,
+      maxevals=C.options.cubature_maxevals))
   end
 
   function principal()
@@ -254,7 +255,8 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies, C::Configuration)
     concertinasinpi = ConcertinaSinpi(principalintegrand, (-az, az))
     output = first(HCubature.hcubature(concertinasinpi,
       (sqrt(eps()), S.F.lower), (1.0 - sqrt(eps()), S.F.upper), initdiv=16,
-      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs))
+      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs,
+      maxevals=C.options.cubature_maxevals))
     @assert !any(isnan, output)
     return output
   end

--- a/src/tensors/CoupledVelocity.jl
+++ b/src/tensors/CoupledVelocity.jl
@@ -241,7 +241,7 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies, C::Configuration)
   function integral2D()
     return first(HCubature.hcubature(integrand,
       (-S.F.upper, lower), (S.F.upper, S.F.upper), initdiv=16,
-      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs,
+      rtol=C.options.cubature_tol.rel, atol=C.options.cubature_tol.abs,
       maxevals=C.options.cubature_maxevals))
   end
 
@@ -255,7 +255,7 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies, C::Configuration)
     concertinasinpi = ConcertinaSinpi(principalintegrand, (-az, az))
     output = first(HCubature.hcubature(concertinasinpi,
       (sqrt(eps()), S.F.lower), (1.0 - sqrt(eps()), S.F.upper), initdiv=16,
-      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs,
+      rtol=C.options.cubature_tol.rel, atol=C.options.cubature_tol.abs,
       maxevals=C.options.cubature_maxevals))
     @assert !any(isnan, output)
     return output
@@ -280,9 +280,9 @@ function coupledvelocity(S::AbstractCoupledVelocitySpecies, C::Configuration)
 
   function perpendicularintegral(∫dv⊥::T, nrm=1) where T
     return first(QuadGK.quadgk(∫dv⊥, S.F.lower, S.F.upper, order=7,
-      atol=max(C.options.quadrature_tol.abs,
-               C.options.quadrature_tol.rel * nrm / 2),
-      rtol=C.options.quadrature_tol.rel))
+      atol=max(C.options.cubature_tol.abs,
+               C.options.cubature_tol.rel * nrm / 2),
+      rtol=C.options.cubature_tol.rel))
   end
 
   # if logic here is a confusing!

--- a/src/tensors/RelativisticMomentum.jl
+++ b/src/tensors/RelativisticMomentum.jl
@@ -197,7 +197,8 @@ function relativisticmomentum(S::CoupledRelativisticSpecies, C::Configuration)
     return first(HCubature.hcubature(
       UnitSemicircleIntegrandTransform(integrand, norm(S.F.normalisation)),
       (0, -π/2), (1, π/2), initdiv=16,
-      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs))
+      rtol=C.options.quadrature_tol.rel, atol=C.options.quadrature_tol.abs,
+      maxevals=C.options.cubature_maxevals))
   end
 
   outertol = C.options.quadrature_tol.rel
@@ -216,7 +217,8 @@ function relativisticmomentum(S::CoupledRelativisticSpecies, C::Configuration)
       objective = transformaboutroots(integrandpz, real(pole(pzroots[1])/pchar))
 
       polefix = wavedirectionalityhandler(pzroots[1])
-      principal = polefix.(first(QuadGK.quadgk(objective, -bound, bound)))
+      principal = polefix.(first(QuadGK.quadgk(objective, -bound, bound, order=7,
+        atol=C.options.quadrature_tol.abs, rtol=C.options.quadrature_tol.rel)))
       principal = sign(real(kz)) .* real(principal) .+ im .* imag(principal)
 
       @assert !any(isnan, principal)# "principal = $principal"

--- a/test/Options.jl
+++ b/test/Options.jl
@@ -20,6 +20,7 @@ using Test
     tol = Tolerance(rtol=0.0, atol=1.0)
     o = Options(tols=tol)
     @test tol == o.quadrature_tol
+    @test tol == o.cubature_tol
     @test tol == o.summation_tol
   end
 

--- a/test/Options.jl
+++ b/test/Options.jl
@@ -22,4 +22,14 @@ using Test
     @test tol == o.quadrature_tol
     @test tol == o.summation_tol
   end
+
+  @testset "cubature_maxevals" begin
+    o = Options(cuba_evals=101)
+    @test o.cubature_maxevals == 101
+    o = Options(maxevals=102)
+    @test o.cubature_maxevals == 102
+    o = Options(cubature_maxevals=103)
+    @test o.cubature_maxevals == 103
+  end
+
 end


### PR DESCRIPTION
Configure cubature tolerance separate to quadrature tolarance, as well as maximum number of evaluations during cubature (but not quadrature, which works fine as is).